### PR TITLE
[BB-3112] Delete codecov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,6 @@ gem 'dalli'
 gem 'rest-client'
 
 group :test do
-  gem 'codecov', :require => false
   gem 'mongoid_cleaner', '~> 1.2.0'
   gem 'factory_girl', '~> 4.0'
   gem 'faker', '~> 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,11 +36,12 @@ GEM
     bson (3.2.4)
     bson_ext (1.5.1)
     builder (3.2.2)
-    codecov (0.1.2)
+    codecov (0.2.6)
+      colorize
       json
       simplecov
-      url
     coderay (1.0.7)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     dalli (2.1.0)
@@ -51,7 +52,7 @@ GEM
       mongoid (>= 3.0, < 6)
       mongoid-compatibility
     diff-lcs (1.1.3)
-    docile (1.1.5)
+    docile (1.3.2)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     elasticsearch (1.1.2)
@@ -84,7 +85,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    json (1.8.3)
+    json (2.3.1)
     kgio (2.10.0)
     listen (0.5.0)
     method_source (0.8)
@@ -145,11 +146,10 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.2)
     safe_yaml (1.0.4)
-    simplecov (0.11.1)
-      docile (~> 1.1.0)
-      json (~> 1.8)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -169,7 +169,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    url (0.3.2)
     webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,6 @@ DEPENDENCIES
   bson (~> 3.1)
   bson_ext
   bundler
-  codecov
   dalli
   delayed_job
   delayed_job_mongoid

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,12 +36,11 @@ GEM
     bson (3.2.4)
     bson_ext (1.5.1)
     builder (3.2.2)
-    codecov (0.2.6)
-      colorize
+    codecov (0.1.2)
       json
       simplecov
+      url
     coderay (1.0.7)
-    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     dalli (2.1.0)
@@ -52,7 +51,7 @@ GEM
       mongoid (>= 3.0, < 6)
       mongoid-compatibility
     diff-lcs (1.1.3)
-    docile (1.3.2)
+    docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     elasticsearch (1.1.2)
@@ -85,7 +84,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    json (2.3.1)
+    json (1.8.3)
     kgio (2.10.0)
     listen (0.5.0)
     method_source (0.8)
@@ -146,10 +145,11 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.2)
     safe_yaml (1.0.4)
-    simplecov (0.18.5)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+    simplecov (0.11.1)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -169,6 +169,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    url (0.3.2)
     webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,10 +36,6 @@ GEM
     bson (3.2.4)
     bson_ext (1.5.1)
     builder (3.2.2)
-    codecov (0.1.2)
-      json
-      simplecov
-      url
     coderay (1.0.7)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -51,7 +47,6 @@ GEM
       mongoid (>= 3.0, < 6)
       mongoid-compatibility
     diff-lcs (1.1.3)
-    docile (1.1.5)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     elasticsearch (1.1.2)
@@ -145,11 +140,6 @@ GEM
       diff-lcs (~> 1.1.3)
     rspec-mocks (2.11.2)
     safe_yaml (1.0.4)
-    simplecov (0.11.1)
-      docile (~> 1.1.0)
-      json (~> 1.8)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
     sinatra (1.3.3)
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
@@ -169,7 +159,6 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    url (0.3.2)
     webmock (1.22.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)


### PR DESCRIPTION
Codecov 0.1.x were yanked from rubygems, causing installation of cs_comments_service to fail.

The initial approach was porting #5, which was ported from the PR against cs_comments_service master: edx#323.
However it's still not working with an older ruby version, so I decided to delete this dependency, as we're not using it anyway. It shouldn't actually be installed, as it's in the `test` group, but since this is a backport that we'll use only temporarily (before upgrading the instance) it didn't make too much sense to dig into this.